### PR TITLE
test: replaced gnulinux with ${OROCOS_TARGET}

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,7 +2,7 @@ pkg_check_modules(BASE REQUIRED "base-lib")
 include_directories(${BASE_INCLUDE_DIRS})
 link_directories(${BASE_LIBRARY_DIRS})
 
-pkg_check_modules(STD REQUIRED "std-typekit-gnulinux")
+pkg_check_modules(STD REQUIRED "std-typekit-${OROCOS_TARGET}")
 include_directories(${STD_INCLUDE_DIRS})
 
 add_definitions("-DOROCOS_TARGET=${OROCOS_TARGET}")


### PR DESCRIPTION
This solved the compiler issue on e.G. xenomai, the target have to be
identified throught the variable, and cannot be static gnulinux
