### PR TITLE
/std/vector</double> is now part of the std typekit

### DIFF
--- a/base.orogen
+++ b/base.orogen
@@ -116,7 +116,6 @@ typekit do
         '/base/Time',
         '/base/Position',
         '/std/vector</base/Vector3d>',
-        '/std/vector</double>',
         '/base/Waypoint',
         '/std/vector</base/Waypoint>',
         '/std/vector</uint32_t>',


### PR DESCRIPTION
Related to rock-core/base-orogen-std#1
