### PR TITLE
move TransformWithUncertainty from envire to base-types

### DIFF
--- a/base.orogen
+++ b/base.orogen
@@ -25,6 +25,7 @@ import_types_from "base/Wrench.hpp"
 import_types_from "base/samples/Wrench.hpp"
 import_types_from "base/samples/Wrenches.hpp"
 import_types_from "base/samples/DepthMap.hpp"
+import_types_from "base/TransformWithUncertainty.hpp"
 import_types_from "base/JointState.hpp"
 import_types_from "base/JointLimits.hpp"
 import_types_from "base/JointTransform.hpp"
@@ -113,6 +114,7 @@ typekit do
         '/base/samples/RigidBodyState',
         '/base/samples/RigidBodyAcceleration',
         '/base/samples/IMUSensors',
+        '/base/TransformWithUncertainty',
         '/base/Wrench',
         '/base/samples/Wrench',
         '/base/samples/Wrenches',

--- a/base.orogen
+++ b/base.orogen
@@ -59,6 +59,7 @@ typekit.opaque_type '/base/Matrix4d', 'wrappers/Matrix4d'
 typekit.opaque_type '/base/Matrix6d', 'wrappers/Matrix6d'
 typekit.opaque_type '/base/MatrixXd', 'wrappers/MatrixXd'
 typekit.opaque_type '/base/VectorXd', 'wrappers/VectorXd'
+typekit.opaque_type '/base/Affine3d', 'wrappers/Matrix4d'
 if has_library?('base-lib')
     import_types_from "base/geometry/Spline.hpp"
 end

--- a/typekit/Opaques.hpp
+++ b/typekit/Opaques.hpp
@@ -95,6 +95,24 @@ namespace orogen_typekits
         real.z() = intermediate.im[2];
     }
 
+    template<typename T, int DIM, int EIGEN_OPTIONS>
+    void toIntermediate(::wrappers::Matrix<T,DIM+1,DIM+1>& intermediate, ::Eigen::Transform<T, DIM, ::Eigen::Affine, EIGEN_OPTIONS> const& real)
+    {
+        typedef Eigen::Matrix<T,DIM+1,DIM+1,EIGEN_OPTIONS> EigenMatrix;
+
+        Eigen::Map<EigenMatrix> m(&(intermediate.data[0]),DIM+1,DIM+1);
+        m = real.matrix();
+    }
+
+    template<typename T, int DIM, int EIGEN_OPTIONS>
+    void fromIntermediate(::Eigen::Transform<T, DIM, ::Eigen::Affine, EIGEN_OPTIONS> real, ::wrappers::Matrix<T,DIM+1,DIM+1> const& intermediate)
+    {
+        typedef const Eigen::Matrix<T,DIM+1,DIM+1,EIGEN_OPTIONS> EigenMatrix;
+
+        Eigen::Map<EigenMatrix> m(&(intermediate.data[0]),DIM+1,DIM+1);
+        real.matrix() = m;
+    }
+
     void toIntermediate(::wrappers::geometry::Spline& intermediate, ::base::geometry::SplineBase const& real_type);
 
     void fromIntermediate(::base::geometry::SplineBase& real_type, ::wrappers::geometry::Spline const& intermediate);


### PR DESCRIPTION
Corresponding type export and opaque conversion for the TransformWithUncertainty type.