### PR TITLE
Export base/commands/LinearAngular6Dcommand

### DIFF
--- a/base.orogen
+++ b/base.orogen
@@ -9,6 +9,7 @@ import_types_from "base/Pressure.hpp"
 import_types_from "base/Time.hpp"
 import_types_from "base/Trajectory.hpp"
 import_types_from "base/commands/AUVMotion.hpp"
+import_types_from "base/commands/LinearAngular6DCommand.hpp"
 import_types_from "base/commands/Motion2D.hpp"
 import_types_from "base/commands/AUVPosition.hpp"
 import_types_from "base/commands/Speed6D.hpp"
@@ -96,6 +97,7 @@ typekit do
     export_types roptr_frame_t,
         roptr_framepair_t,
         '/base/Pose',
+        '/base/commands/LinearAngular6DCommand',
         '/base/commands/Motion2D',
         '/base/commands/Speed6D',
         '/base/commands/AUVMotion',
@@ -106,6 +108,7 @@ typekit do
         '/base/JointTransform',
         '/base/JointTransformVector',
         '/base/JointsTrajectory',
+        '/base/LinearAngular6DCommand',
         '/base/Trajectory',
         '/std/vector</base/Trajectory>',
         '/base/samples/Joints',


### PR DESCRIPTION
@saarnold @doudou 
The type LinearAngular6DCommand has been moved to base/types.

This PR:

   1) Exports new type `base/commands/LinearAngular6DCommand`
   2) Exports typdef for backwards compatibility `base/LinearAngular6DCommand`

This PR depends on:

 - [ ] - https://github.com/rock-core/base-types/pull/96