### PR TITLE
Added base/Matrix2d to export list

### DIFF
--- a/base.orogen
+++ b/base.orogen
@@ -142,6 +142,7 @@ typekit do
         '/base/Vector4d',
         '/base/Vector6d',
         '/base/VectorXd',
+        '/base/Matrix2d',
         '/base/Matrix3d',
         '/base/Matrix4d',
         '/base/Matrix6d',


### PR DESCRIPTION
Fixed the the lack of /base/Matrix2d to the export list.