### PR TITLE
Fix export of optional parts in base/types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,14 +15,18 @@ include_directories(${BOOST_INCLUDE_DIR})
 pkg_check_modules(EIGEN3 REQUIRED "eigen3")
 include_directories(${EIGEN3_INCLUDE_DIRS})
 
-find_package(SISL)
-if (SISL_FOUND)
-    pkg_check_modules(BASELIB REQUIRED "base-lib")
-    include_directories(${BASELIB_INCLUDE_DIRS})
-    include_directories(${SISL_INCLUDE_DIRS})
-    list(APPEND TOOLKIT_ADDITIONAL_SOURCES ${CMAKE_SOURCE_DIR}/src/spline.cpp)
-    list(APPEND TOOLKIT_ADDITIONAL_LIBRARIES ${BASELIB_LIBRARIES} ${SISL_LIBRARIES})
+pkg_check_modules(BASE_TYPES_SISL "base-types-sisl")
+if(NOT BASE_TYPES_SISL_FOUND)
+    message(FATAL_ERROR "The dependency base/types has been built"
+        " without SISL support."
+        " It seems that you have intentially disabled the use of SISL in"
+        " base/types. While disabling SISL support might be useful"
+        " for an isolated reuse of base/types, base/orogen/types or more"
+        " generally the framework Rock strictly requires"
+        " SISL support in base/types. Please rebuild base/types with"
+        " -DUSE_SISL=ON")
 endif()
+list(APPEND TOOLKIT_ADDITIONAL_SOURCES ${CMAKE_SOURCE_DIR}/src/spline.cpp)
 
 INCLUDE(baseBase)
 

--- a/base.orogen
+++ b/base.orogen
@@ -29,20 +29,13 @@ import_types_from "base/JointState.hpp"
 import_types_from "base/JointLimits.hpp"
 import_types_from "base/JointTransform.hpp"
 import_types_from "base/JointsTrajectory.hpp"
-
-if has_library?('base-lib')
-    using_library 'base-lib'
-    # Opaque wrappers for Spline types
-    import_types_from 'base/wrappers/geometry/Spline.hpp'
-end
+import_types_from 'base/wrappers/geometry/Spline.hpp'
 
 # Opaque wrappers for Eigen types
 import_types_from "base/wrappers/Eigen.hpp"
 
-if has_library?('base-lib')
-    typekit.opaque_type '/base/geometry/Spline<3>', '/wrappers/geometry/Spline'
-    typekit.opaque_type '/base/geometry/Spline<1>', '/wrappers/geometry/Spline'
-end
+typekit.opaque_type '/base/geometry/Spline<3>', '/wrappers/geometry/Spline'
+typekit.opaque_type '/base/geometry/Spline<1>', '/wrappers/geometry/Spline'
 typekit.opaque_type '/base/Vector2d', 'wrappers/Vector2d'
 typekit.opaque_type '/base/Vector3d', 'wrappers/Vector3d'
 typekit.opaque_type '/base/Vector4d', 'wrappers/Vector4d'
@@ -56,9 +49,8 @@ typekit.opaque_type '/base/Matrix6d', 'wrappers/Matrix6d'
 typekit.opaque_type '/base/MatrixXd', 'wrappers/MatrixXd'
 typekit.opaque_type '/base/VectorXd', 'wrappers/VectorXd'
 typekit.opaque_type '/base/Affine3d', 'wrappers/Matrix4d'
-if has_library?('base-lib')
-    import_types_from "base/geometry/Spline.hpp"
-end
+
+import_types_from "base/geometry/Spline.hpp"
 import_types_from "base/TwistWithCovariance.hpp"
 import_types_from "base/TransformWithCovariance.hpp"
 import_types_from "base/Pose.hpp"

--- a/manifest.xml
+++ b/manifest.xml
@@ -12,6 +12,7 @@
     </copyright>
   <license>GPL v2 or later</license>
   <depend package="base/types"/>
+  <depend package="external/sisl" />
   <depend package="base/orogen/std"/>
   <depend package="orogen"/>
   <depend package="rtt"/>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-pkg_check_modules(BASE REQUIRED "base-lib")
+pkg_check_modules(BASE REQUIRED "base-types-sisl")
 include_directories(${BASE_INCLUDE_DIRS})
 link_directories(${BASE_LIBRARY_DIRS})
 
@@ -10,10 +10,7 @@ include_directories(${STD_INCLUDE_DIRS})
 
 add_definitions("-DOROCOS_TARGET=${OROCOS_TARGET}")
 
-if (SISL_LIBRARIES)
-    set(ADDITIONAL_TESTS test_nurbs.cpp)
-endif()
-add_executable(base_orogen_types_test test.cpp test_matrixx.cpp
-    ${ADDITIONAL_TESTS} ${TOOLKIT_ADDITIONAL_SOURCES} ../typekit/Opaques.cpp)
+add_executable(base_orogen_types_test test.cpp test_matrixx.cpp test_nurbs.cpp
+    ${TOOLKIT_ADDITIONAL_SOURCES} ../typekit/Opaques.cpp)
 target_link_libraries(base_orogen_types_test ${Boost_SYSTEM_LIBRARIES} ${Boost_UNIT_TEST_FRAMEWORK_LIBRARIES} ${BASE_LIBRARIES})
 


### PR DESCRIPTION
@doudou  Any suggestions to make the Opaques part truely optional. Right now I assume I have to adapt touch orogen to permit injection of extra build flags in base-typekit.pc.in?